### PR TITLE
Add basics for ContentProvider testing.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,15 +28,12 @@ android {
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    resValue("string", "content_provider_authority", "com.g11x.checklistapp.provider")
   }
   buildTypes {
     release {
       minifyEnabled false
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-      resValue("string", "content_provider_authority", "com.g11x.checklistapp.provider")
-    }
-    debug {
-      resValue("string", "content_provider_authority", "com.g11x.checklistapp.provider")
     }
   }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,4 +49,5 @@ dependencies {
   compile 'com.android.support:recyclerview-v7:24.1.0'
 
   testCompile 'junit:junit:4.12'
+  testCompile 'org.mockito:mockito-core:1.10.19'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,6 +33,10 @@ android {
     release {
       minifyEnabled false
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+      resValue("string", "content_provider_authority", "com.g11x.checklistapp.provider")
+    }
+    debug {
+      resValue("string", "content_provider_authority", "com.g11x.checklistapp.provider")
     }
   }
 }

--- a/app/src/androidTest/java/com/g11x/checklistapp/LocalRepositoryTest.java
+++ b/app/src/androidTest/java/com/g11x/checklistapp/LocalRepositoryTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class LocalRepositoryTest extends ProviderTestCase2<LocalRepository> {
     public LocalRepositoryTest() {
-        super(LocalRepository.class, "com.g11x.checklistapp.provider");
+        super(LocalRepository.class, Constants.LOCAL_REPOSITORY_AUTHORITY);
     }
 
     @Override

--- a/app/src/androidTest/java/com/g11x/checklistapp/LocalRepositoryTest.java
+++ b/app/src/androidTest/java/com/g11x/checklistapp/LocalRepositoryTest.java
@@ -1,0 +1,25 @@
+package com.g11x.checklistapp;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.ProviderTestCase2;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Tests for the app's ContentProvider.*/
+@RunWith(AndroidJUnit4.class)
+public class LocalRepositoryTest extends ProviderTestCase2<LocalRepository> {
+    public LocalRepositoryTest() {
+        super(LocalRepository.class, "Some string it needs that I don't understand yet... TDD baby.");
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        setContext(InstrumentationRegistry.getTargetContext());
+        super.setUp();
+    }
+
+    @Test
+    public void shouldFetchData() {}
+}

--- a/app/src/androidTest/java/com/g11x/checklistapp/LocalRepositoryTest.java
+++ b/app/src/androidTest/java/com/g11x/checklistapp/LocalRepositoryTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class LocalRepositoryTest extends ProviderTestCase2<LocalRepository> {
     public LocalRepositoryTest() {
-        super(LocalRepository.class, "Some string it needs that I don't understand yet... TDD baby.");
+        super(LocalRepository.class, "com.g11x.checklistapp.provider");
     }
 
     @Override

--- a/app/src/androidTest/java/com/g11x/checklistapp/LocalRepositoryTest.java
+++ b/app/src/androidTest/java/com/g11x/checklistapp/LocalRepositoryTest.java
@@ -7,11 +7,13 @@ import android.test.ProviderTestCase2;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-/** Tests for the app's ContentProvider.*/
+/**
+ * Tests for the app's ContentProvider.
+ */
 @RunWith(AndroidJUnit4.class)
 public class LocalRepositoryTest extends ProviderTestCase2<LocalRepository> {
     public LocalRepositoryTest() {
-        super(LocalRepository.class, Constants.LOCAL_REPOSITORY_AUTHORITY);
+        super(LocalRepository.class, InstrumentationRegistry.getInstrumentation().getTargetContext().getString(R.string.content_provider_authority));
     }
 
     @Override
@@ -21,5 +23,6 @@ public class LocalRepositoryTest extends ProviderTestCase2<LocalRepository> {
     }
 
     @Test
-    public void shouldFetchData() {}
+    public void shouldFetchData() {
+    }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,6 @@
       android:label="@string/app_name"
       android:supportsRtl="true"
       android:theme="@style/AppTheme"
-      android:exported="false"
       tools:ignore="AllowBackup,GoogleAppIndexingWarning">
     <activity android:name=".ChecklistActivity">
       <intent-filter>
@@ -37,6 +36,10 @@
     <activity android:name=".ChecklistItemActivity">
     </activity>
     <activity android:name=".AboutActivity"/>
+    <provider
+        android:authorities="com.g11x.checklistapp.provider"
+        android:name=".LocalRepository"
+        android:exported="false"
   </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,9 +37,9 @@
     </activity>
     <activity android:name=".AboutActivity"/>
     <provider
-        android:authorities="com.g11x.checklistapp.provider"
+        android:authorities="@string/content_provider_authority"
         android:name=".LocalRepository"
-        android:exported="false"
+        android:exported="false" />
   </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
       android:label="@string/app_name"
       android:supportsRtl="true"
       android:theme="@style/AppTheme"
+      android:exported="false"
       tools:ignore="AllowBackup,GoogleAppIndexingWarning">
     <activity android:name=".ChecklistActivity">
       <intent-filter>

--- a/app/src/main/java/com/g11x/checklistapp/Constants.java
+++ b/app/src/main/java/com/g11x/checklistapp/Constants.java
@@ -1,0 +1,9 @@
+package com.g11x.checklistapp;
+
+/**
+ * Created by wcalabrese on 8/15/16.
+ */
+
+public class Constants {
+    public static final String LOCAL_REPOSITORY_AUTHORITY = "com.g11x.checklistapp.provider";
+}

--- a/app/src/main/java/com/g11x/checklistapp/LocalRepository.java
+++ b/app/src/main/java/com/g11x/checklistapp/LocalRepository.java
@@ -1,0 +1,43 @@
+package com.g11x.checklistapp;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.support.annotation.Nullable;
+
+/** Application data repository. */
+public class LocalRepository extends ContentProvider {
+    @Override
+    public boolean onCreate() {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public Cursor query(Uri uri, String[] strings, String s, String[] strings1, String s1) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getType(Uri uri) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Uri insert(Uri uri, ContentValues contentValues) {
+        return null;
+    }
+
+    @Override
+    public int delete(Uri uri, String s, String[] strings) {
+        return 0;
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues contentValues, String s, String[] strings) {
+        return 0;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,5 +26,4 @@
   <string name="togglebutton">ToggleButton</string>
   <string name="mark_as_not_done">Mark as not done</string>
   <string name="mark_as_done">Mark as done</string>
-  <string name="content_provider_authority">com.google.g11x.checklistapp.provider</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,5 @@
   <string name="togglebutton">ToggleButton</string>
   <string name="mark_as_not_done">Mark as not done</string>
   <string name="mark_as_done">Mark as done</string>
+  <string name="content_provider_authority">com.google.g11x.checklistapp.provider</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha7'
+        classpath 'com.android.tools.build:gradle:2.2.0-beta1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Writing tests is good.
- Added an empty `ContentProvider` called `LocalRepository`. This will serve as the data access point ("repository") for all app data that will be stored locally.
- Added basic testing skeleton for `LocalRepository`.
- Realized that running all of Android to run a simple test isn't great. Roboelectric will be helpful for that.

See https://github.com/g11x/checklistapp/issues/5 for more details.
