### PR TITLE
Content Routing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,16 +27,17 @@
       android:theme="@style/AppTheme"
       tools:ignore="AllowBackup,GoogleAppIndexingWarning">
     <activity android:name=".ChecklistActivity">
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN"/>
-
-        <category android:name="android.intent.category.LAUNCHER"/>
-      </intent-filter>
     </activity>
     <activity android:name=".ChecklistItemActivity">
     </activity>
     <activity android:name=".AboutActivity"/>
-    <activity android:name=".ImportantInformationActivity"/>
+    <activity android:name=".ImportantInformationActivity">
+    <intent-filter>
+      <action android:name="android.intent.action.MAIN"/>
+
+      <category android:name="android.intent.category.LAUNCHER"/>
+    </intent-filter>
+</activity>
     <activity android:name=".ImportantInformationItemActivity"/>
     <provider
         android:authorities="@string/content_provider_authority"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,17 +27,16 @@
       android:theme="@style/AppTheme"
       tools:ignore="AllowBackup,GoogleAppIndexingWarning">
     <activity android:name=".ChecklistActivity">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+
+        <category android:name="android.intent.category.LAUNCHER"/>
+      </intent-filter>
     </activity>
     <activity android:name=".ChecklistItemActivity">
     </activity>
     <activity android:name=".AboutActivity"/>
-    <activity android:name=".ImportantInformationActivity">
-    <intent-filter>
-      <action android:name="android.intent.action.MAIN"/>
-
-      <category android:name="android.intent.category.LAUNCHER"/>
-    </intent-filter>
-</activity>
+    <activity android:name=".ImportantInformationActivity"/>
     <activity android:name=".ImportantInformationItemActivity"/>
     <provider
         android:authorities="@string/content_provider_authority"

--- a/app/src/main/java/com/g11x/checklistapp/LocalRepository.java
+++ b/app/src/main/java/com/g11x/checklistapp/LocalRepository.java
@@ -12,78 +12,81 @@ import android.support.annotation.Nullable;
 
 import com.g11x.checklistapp.data.Database;
 
-/** Application data repository. */
+/**
+ * Application data repository.
+ */
 public class LocalRepository extends ContentProvider {
-    // A string that defines the SQL statement for creating a table
-    private static final String SQL_CREATE_MAIN =
-        "CREATE TABLE important_info "
-        + "(_ID INTEGER PRIMARY KEY, INFO TEXT);";
+  // A string that defines the SQL statement for creating a table
+  private static final String SQL_CREATE_MAIN =
+      "CREATE TABLE important_info "
+          + "(_ID INTEGER PRIMARY KEY, INFO TEXT);";
 
-     // Helper class that actually creates and manages the provider's underlying data repository.
-    protected static final class MainDatabaseHelper extends SQLiteOpenHelper {
-        // Instantiates an open helper for the provider's SQLite data repository. Do not do database
-        // creation and upgrade here.
-        MainDatabaseHelper(Context context) {
-            super(context, Database.NAME, null, 1);
-        }
-
-        // Creates the data repository. This is called when the provider attempts to open the
-        // repository and SQLite reports that it doesn't exist.
-        public void onCreate(SQLiteDatabase db) {
-            // Creates the main table
-            db.execSQL(SQL_CREATE_MAIN);
-        }
-
-        @Override
-        public void onUpgrade(SQLiteDatabase sqLiteDatabase, int i, int i1) {
-            // TODO: This seems useful. Learn how to use it.
-        }
+  // Helper class that actually creates and manages the provider's underlying data repository.
+  protected static final class MainDatabaseHelper extends SQLiteOpenHelper {
+    // Instantiates an open helper for the provider's SQLite data repository. Do not do database
+    // creation and upgrade here.
+    MainDatabaseHelper(Context context) {
+      super(context, Database.NAME, null, 1);
     }
 
-    // Defines a handle to the database helper object. The MainDatabaseHelper class is defined in a
-    // following snippet.
-    private MainDatabaseHelper openHelper;
-
-    // Holds the database object
-    private SQLiteDatabase db;
-
-    @Override
-    public boolean onCreate() {
-        // Creates a new helper object. This method always returns quickly. Notice that the
-        // database itself isn't created or opened until SQLiteOpenHelper.getWritableDatabase
-        // is called.
-        openHelper = new MainDatabaseHelper(getContext());
-        return true;
-    }
-
-    @Nullable
-    @Override
-    public Cursor query(Uri uri, String[] strings, String s, String[] strings1, String s1) {
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public String getType(Uri uri) {
-        return null;
-    }
-
-    @Nullable
-    @Override
-    public Uri insert(Uri uri, ContentValues contentValues) {
-        // Gets a writeable database. This will trigger its creation if it doesn't already exist.
-        db = openHelper.getWritableDatabase();
-        long id = db.insert(Database.ImportantInformation.INFO_COLUMN, null, contentValues);
-        return ContentUris.withAppendedId(uri, id);
+    // Creates the data repository. This is called when the provider attempts to open the
+    // repository and SQLite reports that it doesn't exist.
+    public void onCreate(SQLiteDatabase db) {
+      // Creates the main table
+      db.execSQL(SQL_CREATE_MAIN);
     }
 
     @Override
-    public int delete(Uri uri, String s, String[] strings) {
-        return 0;
+    public void onUpgrade(SQLiteDatabase sqLiteDatabase, int i, int i1) {
+      // TODO: This seems useful. Learn how to use it.
     }
+  }
 
-    @Override
-    public int update(Uri uri, ContentValues contentValues, String s, String[] strings) {
-        return 0;
-    }
+  // Defines a handle to the database helper object. The MainDatabaseHelper class is defined in a
+  // following snippet.
+  private MainDatabaseHelper openHelper;
+
+  // Holds the database object
+  private SQLiteDatabase db;
+
+  @Override
+  public boolean onCreate() {
+    // Creates a new helper object. This method always returns quickly. Notice that the
+    // database itself isn't created or opened until SQLiteOpenHelper.getWritableDatabase
+    // is called.
+    openHelper = new MainDatabaseHelper(getContext());
+    return true;
+  }
+
+  @Nullable
+  @Override
+  public Cursor query(Uri uri, String[] strings, String s, String[] strings1, String s1) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getType(Uri uri) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Uri insert(Uri uri, ContentValues contentValues) {
+    // Gets a writeable database. This will trigger its creation if it doesn't already exist.
+    db = openHelper.getWritableDatabase();
+
+    Database.TableHandler handler = Database.getTableHandler(db, uri);
+    return handler.insert(contentValues);
+  }
+
+  @Override
+  public int delete(Uri uri, String s, String[] strings) {
+    return 0;
+  }
+
+  @Override
+  public int update(Uri uri, ContentValues contentValues, String s, String[] strings) {
+    return 0;
+  }
 }

--- a/app/src/main/java/com/g11x/checklistapp/LocalRepository.java
+++ b/app/src/main/java/com/g11x/checklistapp/LocalRepository.java
@@ -1,7 +1,6 @@
 package com.g11x.checklistapp;
 
 import android.content.ContentProvider;
-import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -16,38 +15,9 @@ import com.g11x.checklistapp.data.Database;
  * Application data repository.
  */
 public class LocalRepository extends ContentProvider {
-  // A string that defines the SQL statement for creating a table
-  private static final String SQL_CREATE_MAIN =
-      "CREATE TABLE important_info "
-          + "(_ID INTEGER PRIMARY KEY, INFO TEXT);";
-
-  // Helper class that actually creates and manages the provider's underlying data repository.
-  protected static final class MainDatabaseHelper extends SQLiteOpenHelper {
-    // Instantiates an open helper for the provider's SQLite data repository. Do not do database
-    // creation and upgrade here.
-    MainDatabaseHelper(Context context) {
-      super(context, Database.NAME, null, 1);
-    }
-
-    // Creates the data repository. This is called when the provider attempts to open the
-    // repository and SQLite reports that it doesn't exist.
-    public void onCreate(SQLiteDatabase db) {
-      // Creates the main table
-      db.execSQL(SQL_CREATE_MAIN);
-    }
-
-    @Override
-    public void onUpgrade(SQLiteDatabase sqLiteDatabase, int i, int i1) {
-      // TODO: This seems useful. Learn how to use it.
-    }
-  }
-
   // Defines a handle to the database helper object. The MainDatabaseHelper class is defined in a
   // following snippet.
   private MainDatabaseHelper openHelper;
-
-  // Holds the database object
-  private SQLiteDatabase db;
 
   @Override
   public boolean onCreate() {
@@ -73,10 +43,7 @@ public class LocalRepository extends ContentProvider {
   @Nullable
   @Override
   public Uri insert(Uri uri, ContentValues contentValues) {
-    // Gets a writeable database. This will trigger its creation if it doesn't already exist.
-    db = openHelper.getWritableDatabase();
-
-    Database.TableHandler handler = Database.getTableHandler(db, uri);
+    Database.TableHandler handler = Database.getTableHandler(openHelper.getWritableDatabase(), uri);
     return handler.insert(contentValues);
   }
 
@@ -88,5 +55,26 @@ public class LocalRepository extends ContentProvider {
   @Override
   public int update(Uri uri, ContentValues contentValues, String s, String[] strings) {
     return 0;
+  }
+
+  // Helper class that actually creates and manages the provider's underlying data repository.
+  protected static final class MainDatabaseHelper extends SQLiteOpenHelper {
+    // Instantiates an open helper for the provider's SQLite data repository. Do not do database
+    // creation and upgrade here.
+    MainDatabaseHelper(Context context) {
+      super(context, Database.NAME, null, 1);
+    }
+
+    // Creates the data repository. This is called when the provider attempts to open the
+    // repository and SQLite reports that it doesn't exist.
+    public void onCreate(SQLiteDatabase db) {
+      // Creates the main table
+      db.execSQL(Database.ImportantInformation.CREATE_TABLE_SQL);
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase sqLiteDatabase, int i, int i1) {
+      // TODO: This seems useful. Learn how to use it.
+    }
   }
 }

--- a/app/src/main/java/com/g11x/checklistapp/LocalRepository.java
+++ b/app/src/main/java/com/g11x/checklistapp/LocalRepository.java
@@ -43,8 +43,7 @@ public class LocalRepository extends ContentProvider {
   @Nullable
   @Override
   public Uri insert(Uri uri, ContentValues contentValues) {
-    Database.TableHandler handler = Database.getTableHandler(openHelper.getWritableDatabase(), uri);
-    return handler.insert(contentValues);
+    return Database.insert(openHelper.getWritableDatabase(), uri, contentValues);
   }
 
   @Override

--- a/app/src/main/java/com/g11x/checklistapp/data/Database.java
+++ b/app/src/main/java/com/g11x/checklistapp/data/Database.java
@@ -31,10 +31,6 @@ public class Database {
     return Database.getTableHandler(db, uri).insert(contentValues);
   }
 
-  public interface TableHandler {
-    Uri insert(ContentValues contentValues);
-  }
-
   /** Information representing the ImportantInformation content..*/
   public static class ImportantInformation {
     /** Important information table content URI. */
@@ -52,7 +48,7 @@ public class Database {
       private final SQLiteDatabase db;
       private final Uri contentUri;
 
-      public ImportantInformationTable(SQLiteDatabase db, Uri contentUri) {
+      ImportantInformationTable(SQLiteDatabase db, Uri contentUri) {
         this.db = db;
         this.contentUri = contentUri;
       }
@@ -82,6 +78,10 @@ public class Database {
     matcher.addURI("com.g11x.checklistapp.provider", Database.NAME + "/" + ImportantInformation.TABLE_NAME, 1);
 
     return matcher;
+  }
+
+  private interface TableHandler {
+    Uri insert(ContentValues contentValues);
   }
 
   private static TableHandler getTableHandler(SQLiteDatabase db, Uri contentUri) {

--- a/app/src/main/java/com/g11x/checklistapp/data/Database.java
+++ b/app/src/main/java/com/g11x/checklistapp/data/Database.java
@@ -19,45 +19,71 @@ package com.g11x.checklistapp.data;
 
 import android.content.ContentUris;
 import android.content.ContentValues;
+import android.content.UriMatcher;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 
-/**
- * Important domain concepts for manipulating the ImportantInformation model.
- */
+/** Important domain concepts for manipulating the ImportantInformation model. */
 public class Database {
   public static final String NAME = "g11x_checklistapp";
 
   public static TableHandler getTableHandler(SQLiteDatabase db, Uri contentUri) {
-    return new ImportantInformation.ImportantInformationTable(db, contentUri);
+    switch (URI_MATCHER.match(contentUri)) {
+      case 1:
+        return new ImportantInformation.ImportantInformationTable(db, contentUri);
+      default:
+        throw new RuntimeException(String.format("No handler registered for %s", contentUri));
+    }
   }
 
   public interface TableHandler {
     Uri insert(ContentValues contentValues);
   }
 
+  /** Information representing the ImportantInformation content..*/
   public static class ImportantInformation {
-    // Important information table content URI.
-    // TODO: Figure out how to use getString(R.string.content_provider_authority) here.
-    public static final Uri CONTENT_URI;
+    /** Important information table content URI. */
+    public static final Uri CONTENT_URI = createContentUri();
 
-    // Important information table info column.
+    /** Info column name. */
     public static final String INFO_COLUMN = "info";
+
+    /** A string that defines the SQL statement for creating a table. */
+    public static final String CREATE_TABLE_SQL = createCreateTableSql();
 
     private static final String TABLE_NAME = "important_information";
 
-    static {
-      CONTENT_URI = Uri.parse("content://com.g11x.checklistapp/" + Database.NAME + "/" + TABLE_NAME);
-    }
-
     private static class ImportantInformationTable implements TableHandler {
-      public ImportantInformationTable(SQLiteDatabase db, Uri contentUri) {}
+      private final SQLiteDatabase db;
+      private final Uri contentUri;
+
+      public ImportantInformationTable(SQLiteDatabase db, Uri contentUri) {
+        this.db = db;
+        this.contentUri = contentUri;
+      }
       
       @Override
       public Uri insert(ContentValues contentValues) {
-        long id = db.insert(Database.ImportantInformation.INFO_COLUMN, null, contentValues);
-        return ContentUris.withAppendedId(uri, id);
+        long id = db.insert(Database.ImportantInformation.TABLE_NAME, null, contentValues);
+        return ContentUris.withAppendedId(contentUri, id);
       }
     }
+
+    private static Uri createContentUri() {
+      // TODO: Figure out how to use getString(R.string.content_provider_authority) here.
+      return Uri.parse("content://com.g11x.checklistapp.provider/" + Database.NAME + "/" + TABLE_NAME);
+    }
+
+    private static String createCreateTableSql() {
+      return "create table " + TABLE_NAME + " (_ID integer primary key, " + INFO_COLUMN + " text);";
+    }
+  }
+
+  private static final UriMatcher URI_MATCHER = createContentRouter();
+
+  private static UriMatcher createContentRouter() {
+    UriMatcher matcher = new UriMatcher(UriMatcher.NO_MATCH);
+    matcher.addURI("com.g11x.checklistapp.provider", Database.NAME + "/" + ImportantInformation.TABLE_NAME, 1);
+    return matcher;
   }
 }

--- a/app/src/main/java/com/g11x/checklistapp/data/Database.java
+++ b/app/src/main/java/com/g11x/checklistapp/data/Database.java
@@ -17,6 +17,9 @@
 
 package com.g11x.checklistapp.data;
 
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 
 /**
@@ -24,6 +27,14 @@ import android.net.Uri;
  */
 public class Database {
   public static final String NAME = "g11x_checklistapp";
+
+  public static TableHandler getTableHandler(SQLiteDatabase db, Uri contentUri) {
+    return new ImportantInformation.ImportantInformationTable(db, contentUri);
+  }
+
+  public interface TableHandler {
+    Uri insert(ContentValues contentValues);
+  }
 
   public static class ImportantInformation {
     // Important information table content URI.
@@ -37,6 +48,16 @@ public class Database {
 
     static {
       CONTENT_URI = Uri.parse("content://com.g11x.checklistapp/" + Database.NAME + "/" + TABLE_NAME);
+    }
+
+    private static class ImportantInformationTable implements TableHandler {
+      public ImportantInformationTable(SQLiteDatabase db, Uri contentUri) {}
+      
+      @Override
+      public Uri insert(ContentValues contentValues) {
+        long id = db.insert(Database.ImportantInformation.INFO_COLUMN, null, contentValues);
+        return ContentUris.withAppendedId(uri, id);
+      }
     }
   }
 }

--- a/app/src/main/java/com/g11x/checklistapp/data/Database.java
+++ b/app/src/main/java/com/g11x/checklistapp/data/Database.java
@@ -27,13 +27,8 @@ import android.net.Uri;
 public class Database {
   public static final String NAME = "g11x_checklistapp";
 
-  public static TableHandler getTableHandler(SQLiteDatabase db, Uri contentUri) {
-    switch (URI_MATCHER.match(contentUri)) {
-      case 1:
-        return new ImportantInformation.ImportantInformationTable(db, contentUri);
-      default:
-        throw new RuntimeException(String.format("No handler registered for %s", contentUri));
-    }
+  public static Uri insert(SQLiteDatabase db, Uri uri, ContentValues contentValues) {
+    return Database.getTableHandler(db, uri).insert(contentValues);
   }
 
   public interface TableHandler {
@@ -83,7 +78,18 @@ public class Database {
 
   private static UriMatcher createContentRouter() {
     UriMatcher matcher = new UriMatcher(UriMatcher.NO_MATCH);
+
     matcher.addURI("com.g11x.checklistapp.provider", Database.NAME + "/" + ImportantInformation.TABLE_NAME, 1);
+
     return matcher;
+  }
+
+  private static TableHandler getTableHandler(SQLiteDatabase db, Uri contentUri) {
+    switch (URI_MATCHER.match(contentUri)) {
+      case 1:
+        return new ImportantInformation.ImportantInformationTable(db, contentUri);
+      default:
+        throw new RuntimeException(String.format("No handler registered for %s", contentUri));
+    }
   }
 }


### PR DESCRIPTION
Database clients need to be able to manipulate various tables in the local repository. These are identified by them by a URI of the form `content://<content_authority>/<database>/<table>`. The database layer must use this URI to route the request to do the right thing.

This change adds an initial pass at this type of routing. Once we have a couple more tables to manipulate, we can refine our approach.
