### PR TITLE
i18n stuff

### DIFF
--- a/app/src/main/java/com/g11x/checklistapp/language/PreferredLanguageSupport.java
+++ b/app/src/main/java/com/g11x/checklistapp/language/PreferredLanguageSupport.java
@@ -33,6 +33,8 @@ import java.util.Locale;
  * {@link Context}.
  */
 public class PreferredLanguageSupport {
+  private static final Locale DEFAULT_LOCALE = Locale.getDefault();
+
   public static void applyPreferredLanguage(@NonNull Context context) {
     Language language = AppPreferences.getLanguageOverride(context);
     if (language != null && language != Language.SystemDefault) {
@@ -61,9 +63,9 @@ public class PreferredLanguageSupport {
     Configuration conf = resources.getConfiguration();
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
       //noinspection deprecation Can't remove until minSdk > 17
-      conf.locale = Locale.getDefault();
+      conf.locale = DEFAULT_LOCALE;
     } else {
-      conf.setLocale(Locale.getDefault());
+      conf.setLocale(DEFAULT_LOCALE);
     }
     resources.updateConfiguration(conf, dm);
   }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -16,18 +16,6 @@
   -->
 
 <resources>
-  <string name="app_name">RST Checklist</string>
-  <string name="about_text">This app contains code that is \u00A9 Google</string>
-  <string name="about">About</string>
-  <string name="get_social_security_card">Get social security card</string>
-  <string name="description_text">Description text.</string>
-  <string name="get_directions">Get directions</string>
-  <string name="togglebutton">ToggleButton</string>
-  <string name="mark_as_not_done">Mark as not done</string>
-  <string name="mark_as_done">Mark as done</string>
-  <string name="title">Title</string>
-  <string name="create">Create</string>
-  <string name="created_important_information_item">Created %s</string>
   <string name="navdrawer_item_checklist">Список заданий</string>
   <string name="navdrawer_item_important_info">Заметки</string>
   <string name="navdrawer_item_notifications">Уведомления</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -16,19 +16,6 @@
   -->
 
 <resources>
-  <string name="app_name">RST Checklist</string>
-  <string name="about_text">This app contains code that is \u00A9 Google</string>
-  <string name="about">About</string>
-  <string name="apache_license_link"><a href="https://raw.githubusercontent.com/g11x/checklistapp/master/LICENSE">Licensed under Apache 2.0</a></string>
-  <string name="get_social_security_card">Get social security card</string>
-  <string name="description_text">Description text.</string>
-  <string name="get_directions">Get directions</string>
-  <string name="togglebutton">ToggleButton</string>
-  <string name="mark_as_not_done">Mark as not done</string>
-  <string name="mark_as_done">Mark as done</string>
-  <string name="title">Title</string>
-  <string name="create">Create</string>
-  <string name="created_important_information_item">Created %s</string>
   <string name="navdrawer_item_checklist">Список завдань</string>
   <string name="navdrawer_item_important_info">Нотатки</string>
   <string name="navdrawer_item_notifications">Повідомлення</string>

--- a/bin/strings_to_csv.py
+++ b/bin/strings_to_csv.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+import collections, csv, itertools, json, os, re, sys
+import xml.etree.ElementTree
+
+TRANSLATABLE_FIELDS = ('name', 'description')
+DEFAULT_LANGUAGE = 'en'
+LOCALES = ('uk', 'ru')
+STRINGS_FILE_RE = re.compile(r'^strings\.xml$')
+
+
+def encode_tuple((k, v), encoding='utf-8'):
+  return (k.encode(encoding), v.encode(encoding) if v != None else v)
+
+
+def encode_dict(d, encoding='utf-8'):
+  return dict(map(encode_tuple, d.iteritems()))
+
+
+def db_translations():
+  db = json.load(open('app/testdata/checklistappdev-export.json'))
+  for index, item in enumerate(db['checklists']['basic']):
+    for field in TRANSLATABLE_FIELDS:
+      record = {
+        'location': 'db[{}]'.format(index),
+        'field': field,
+        DEFAULT_LANGUAGE: item[field]
+      }
+      for locale in LOCALES:
+        record[locale] = item.get('alt', {}).get(locale, {}).get(field, None)
+      yield record
+
+
+def strings_xml_filenames():
+  for (directory, _, files) in os.walk('app/src/main/res'):
+    for file_ in files:
+      if STRINGS_FILE_RE.match(file_):
+        yield os.path.join(directory, file_)
+
+
+def language_from_filename(filename):
+  values_dir = os.path.split(os.path.dirname(filename))[1]
+  try:
+    return values_dir.rsplit('-')[1]
+  except IndexError:
+    return DEFAULT_LANGUAGE
+
+
+def filename_without_locale(filename):
+  res_dir = os.path.split(os.path.dirname(filename))[0]
+  return os.path.join(res_dir, 'values', os.path.basename(filename))
+
+
+def language_translation_from_filename(filename):
+  language = language_from_filename(filename)
+  for event, element in xml.etree.ElementTree.iterparse(filename):
+    if element.tag == 'string':
+      yield {
+        'location': filename_without_locale(filename),
+        'field': element.attrib['name'],
+        language: element.text,
+      }
+
+
+def code_translations():
+  translation_map = collections.defaultdict(lambda: {})
+  for filename in strings_xml_filenames():
+    for language_translation in language_translation_from_filename(filename):
+      key = language_translation['location'] + language_translation['field']
+      translation_map[key].update(language_translation)
+  return translation_map.values()
+
+
+def translations_to_csv(translations, outfile):
+  fieldnames = ('location', 'field', DEFAULT_LANGUAGE) + LOCALES
+  writer = csv.DictWriter(outfile, fieldnames=fieldnames)
+  writer.writeheader()
+  for translation in translations:
+    writer.writerow(encode_dict(translation))
+
+
+if __name__ == '__main__':
+  translations_to_csv(itertools.chain(code_translations(), db_translations()),
+      outfile=sys.stdout)


### PR DESCRIPTION
- add a utility for making a CSV of strings to make it easier to solicit
  translations
- remove english from uk/ru strings files
- fix a bug that resulted in parts of the app showing the system default
  strings, and parts not.
  - specifically, `Locale.getDefault()` returns a different locale after
    `resources.updateConfiguration()` is called. so if you switch to uk,
    then to the system default, `Locale.getDefault()` would return uk,
    resulting in the nav not going back to english. i understand that if
    the user changes the system language, this app won't reflect that
    change, but that seems less bad than a UI showing two different
    languages.
